### PR TITLE
🪲 Fix totalAssets() and maxTotalUnlock() logic

### DIFF
--- a/src/AfCvx.sol
+++ b/src/AfCvx.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import { Ownable } from "solady/auth/Ownable.sol";
 import { FixedPointMathLib } from "solady/utils/FixedPointMathLib.sol";
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
+import { SafeCastLib } from "solady/utils/SafeCastLib.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { ERC20PermitUpgradeable } from
@@ -23,6 +24,7 @@ import { Zap } from "./utils/Zap.sol";
 contract AfCvx is IAfCvx, TrackedAllowances, Ownable, ERC4626Upgradeable, ERC20PermitUpgradeable, UUPSUpgradeable {
     using SafeTransferLib for address;
     using FixedPointMathLib for uint256;
+    using SafeCastLib for *;
 
     uint256 internal constant BASIS_POINT_SCALE = 10000;
 
@@ -98,19 +100,36 @@ contract AfCvx is IAfCvx, TrackedAllowances, Ownable, ERC4626Upgradeable, ERC20P
     }
 
     function totalAssets() public view override(ERC4626Upgradeable, IERC4626) returns (uint256) {
-        (uint256 unlocked, uint256 lockedInClever, uint256 staked) = _getAvailableAssets();
-        return unlocked + lockedInClever + staked;
+        (uint256 unlocked, uint256 lockedInClever, uint256 staked, uint256 unlockObligations) = _getAvailableAssets();
+
+        // Should not overflow.
+        // The unlock obligations can be greater than `deposited - borrowed` in Clever
+        // if `repay()` and `unlock()` in `cleverCvxStrategy` aren't called at the end of each epoch.
+        // If `harvest()` also isn't called regularly the rewards are left in Furnace and `lockedInClever`
+        // is calculated as `deposited - borrowed + rewards`.
+        // If `harvest()` is called, the rewards are transferred to afCVX and they become a part of `unlock` balance.
+        return unlocked + lockedInClever + staked - unlockObligations;
     }
 
-    function getAvailableAssets() external view returns (uint256 unlocked, uint256 lockedInClever, uint256 staked) {
-        (unlocked, lockedInClever, staked) = _getAvailableAssets();
+    function getAvailableAssets()
+        external
+        view
+        returns (uint256 unlocked, uint256 lockedInClever, uint256 staked, uint256 unlockObligations)
+    {
+        (unlocked, lockedInClever, staked, unlockObligations) = _getAvailableAssets();
     }
 
-    function _getAvailableAssets() private view returns (uint256 unlocked, uint256 lockedInClever, uint256 staked) {
+    function _getAvailableAssets()
+        private
+        view
+        returns (uint256 unlocked, uint256 lockedInClever, uint256 staked, uint256 unlockObligations)
+    {
         unlocked = CVX.balanceOf(address(this));
 
         // NOTE: clevCVX is assumed to be 1:1 with CVX
-        (uint256 deposited, uint256 rewards) = cleverCvxStrategy.totalValue();
+        uint256 deposited;
+        uint256 rewards;
+        (deposited, rewards, unlockObligations) = cleverCvxStrategy.totalValue();
         lockedInClever = deposited + (rewards == 0 ? 0 : (rewards - _mulBps(rewards, protocolFeeBps)));
 
         // NOTE: we consider only staked CVX in Convex and ignore the rewards, as they are paid in cvxCRV
@@ -397,23 +416,34 @@ contract AfCvx is IAfCvx, TrackedAllowances, Ownable, ERC4626Upgradeable, ERC20P
         emit WeeklyWithdrawLimitUpdated(withdrawalLimit, nextUpdate);
     }
 
+    /// @notice Simulates the effect of assets distribution between strategies.
+    /// @return cleverDepositAmount The amount of CVX to deposit in Clever Strategy.
+    /// @return convexStakeAmount The amount of CVX to stake in Convex Rewards Pool.
     function previewDistribute() external view returns (uint256 cleverDepositAmount, uint256 convexStakeAmount) {
         (cleverDepositAmount, convexStakeAmount) = _previewDistribute();
     }
 
     function _previewDistribute() private view returns (uint256 cleverDepositAmount, uint256 convexStakeAmount) {
-        (uint256 unlocked, uint256 lockedInClever, uint256 staked) = _getAvailableAssets();
+        (uint256 unlocked, uint256 lockedInClever, uint256 staked, uint256 unlockObligations) = _getAvailableAssets();
         if (unlocked == 0) return (0, 0);
 
-        uint256 totalLocked = lockedInClever + staked;
-        uint256 targetLockedInClever = _mulBps(unlocked + totalLocked, cleverStrategyShareBps);
-        if (targetLockedInClever >= lockedInClever) {
-            uint256 delta;
-            unchecked {
-                delta = targetLockedInClever - lockedInClever;
-            }
-            cleverDepositAmount = delta > unlocked ? unlocked : delta;
-        }
+        // There is a possibility that the total value locked in Clever strategy is less than the unlock obligations.
+        // It can only happen if `borrow()` and `unlock()` aren't called at the end of each epoch
+        // but `harvest()` is called and Clever/Furnace rewards are transferred from CleverCvxStrategy to afCVX.
+        int256 currentLockedInClever = lockedInClever.toInt256() - unlockObligations.toInt256();
+
+        // Should not overflow. If `currentLockedInClever` < 0, Clever/Furnace rewards are part of `unlock` balance.
+        uint256 total = ((unlocked + staked).toInt256() + currentLockedInClever).toUint256();
+
+        // The ideal amount of assets in Clever strategy based on the strategy share.
+        int256 targetLockedInClever = _mulBps(total, cleverStrategyShareBps).toInt256();
+        int256 delta = targetLockedInClever - currentLockedInClever;
+
+        // The current total value locked in Clever strategy is greater than ideal.
+        // All available balance is distributed to Convex strategy.
+        if (delta <= 0) return (0, unlocked);
+
+        cleverDepositAmount = unlocked.min(delta.toUint256());
 
         if (unlocked > cleverDepositAmount) {
             unchecked {
@@ -426,7 +456,7 @@ contract AfCvx is IAfCvx, TrackedAllowances, Ownable, ERC4626Upgradeable, ERC20P
     //                     OPERATOR FUNCTIONS                      //
     /////////////////////////////////////////////////////////////////
 
-    /// @notice distributes the deposited CVX between CLever Strategy and Convex Rewards Pool
+    /// @notice Distributes the deposited CVX between Clever Strategy and Convex Rewards Pool
     function distribute(bool swap, uint256 minAmountOut) external onlyOperatorOrOwner {
         (uint256 cleverDepositAmount, uint256 convexStakeAmount) = _previewDistribute();
 

--- a/src/interfaces/afCvx/IAfCvx.sol
+++ b/src/interfaces/afCvx/IAfCvx.sol
@@ -32,7 +32,10 @@ interface IAfCvx is IERC4626 {
     event UnlockedWithdrawn(address indexed sender, address indexed receiver, uint256 amount);
     event WeeklyWithdrawLimitUpdated(uint256 indexed withdrawLimit, uint256 nextUpdateDate);
 
-    function getAvailableAssets() external view returns (uint256 unlocked, uint256 lockedInClever, uint256 staked);
+    function getAvailableAssets()
+        external
+        view
+        returns (uint256 unlocked, uint256 lockedInClever, uint256 staked, uint256 unlockObligations);
     function previewDistribute() external view returns (uint256 cleverDepositAmount, uint256 convexStakeAmount);
     function previewRequestUnlock(uint256 assets) external view returns (uint256);
     function distribute(bool swap, uint256 minAmountOut) external;

--- a/src/interfaces/afCvx/ICleverCvxStrategy.sol
+++ b/src/interfaces/afCvx/ICleverCvxStrategy.sol
@@ -20,7 +20,7 @@ interface ICleverCvxStrategy {
     event OperatorSet(address indexed newOperator);
     event EmergencyShutdown();
 
-    function totalValue() external view returns (uint256 deposited, uint256 rewards);
+    function totalValue() external view returns (uint256 deposited, uint256 rewards, uint256 obligations);
     function maxTotalUnlock() external view returns (uint256 maxUnlock);
     function deposit(uint256 cvxAmount, bool swap, uint256 minAmountOut) external;
     function borrow() external;

--- a/test/AfCvx.harvest.t.sol
+++ b/test/AfCvx.harvest.t.sol
@@ -31,7 +31,7 @@ contract AfCvxHarvestForkTest is BaseForkTest {
         // simulate Furnace rewards
         _distributeFurnaceRewards(10 ether);
 
-        (, uint256 cleverRewards) = cleverCvxStrategy.totalValue();
+        (, uint256 cleverRewards,) = cleverCvxStrategy.totalValue();
         assertGt(cleverRewards, 0, "no clever rewards");
 
         vm.prank(owner);

--- a/test/AfCvx.totalAssets.t.sol
+++ b/test/AfCvx.totalAssets.t.sol
@@ -97,10 +97,19 @@ contract AfCvxTotalAssetsForkTest is BaseForkTest {
         assertEq(unrealised, 0);
         assertEq(realised, 40e18);
 
-        // The reported Clever rewards value was decreased to keep keep total assets value accurate
-        (uint256 deposited, uint256 rewards) = cleverCvxStrategy.totalValue();
-        assertEq(deposited, 0);
-        assertEq(rewards, 29.6e18);
+        (uint256 deposited, uint256 rewards, uint256 unlockObligations) = cleverCvxStrategy.totalValue();
+        assertEq(deposited, 39.6e18);
+        assertEq(rewards, 40e18);
+        assertEq(unlockObligations, 50e18);
         assertEq(afCvx.totalAssets(), 49.6e18);
+
+        vm.prank(operator);
+        afCvx.harvest(0);
+
+        (deposited, rewards, unlockObligations) = cleverCvxStrategy.totalValue();
+        assertEq(deposited, 39.6e18);
+        assertEq(rewards, 0);
+        assertEq(unlockObligations, 50e18);
+        assertApproxEqAbs(afCvx.totalAssets(), 49.6e18, 0.03e18);
     }
 }

--- a/test/utils/BaseForkTest.sol
+++ b/test/utils/BaseForkTest.sol
@@ -150,20 +150,17 @@ abstract contract BaseForkTest is Test {
         vm.stopPrank();
     }
 
-    function _mockCleverTotalValue(uint256 deposited, uint256 rewards) internal {
+    function _mockCleverTotalValue(uint256 deposited, uint256 rewards, uint256 unlockObligations) internal {
         vm.mockCall(
             address(cleverCvxStrategy),
             abi.encodeWithSelector(cleverCvxStrategy.totalValue.selector),
-            abi.encode(deposited, rewards)
+            abi.encode(deposited, rewards, unlockObligations)
         );
     }
 
-    function _mockStakedTotalValue(uint256 staked, uint256 rewards) internal {
+    function _mockStakedTotalValue(uint256 staked) internal {
         vm.mockCall(
             address(CVX_REWARDS_POOL), abi.encodeWithSelector(CVX_REWARDS_POOL.balanceOf.selector), abi.encode(staked)
-        );
-        vm.mockCall(
-            address(CVX_REWARDS_POOL), abi.encodeWithSelector(CVX_REWARDS_POOL.earned.selector), abi.encode(rewards)
         );
     }
 


### PR DESCRIPTION
In this PR:

- refactored `totalValue` function in CleverCvxStrategy to return `unlockObligations` in addition to deposited amount and rewards to prevent incorrect total value reporting after harvesting.
- fixed `maxTotalUnlock` function in CleverCvxStrategy to account for a scenario when assets deposited in Furnace is greater than the borrowed amount.